### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 Encode html to its component plain-text and meta style parts
 
 ```javascript
-{ encode, decode } = require('html-text-weaver');
+const Weaver = require('html-text-weaver');
+const { encode, decode } = new Weaver();
 
 const html = '<h1>Hey, you! <b><i>Get out of there!</i></b></h1>';
 


### PR DESCRIPTION
Hey, I was reading your blog post [1] that I found on HackerNews. I noticed that the blog post and the README here were incorrect. Besides that, it's clever to separate the plain text from it's representation.

[1] https://frameableinc.com/tech/introducing-html-text-weaver